### PR TITLE
Add cart functionality via redis

### DIFF
--- a/app/Http/Controllers/Frontend/Package/EssentialsController.php
+++ b/app/Http/Controllers/Frontend/Package/EssentialsController.php
@@ -65,14 +65,19 @@ class EssentialsController extends Controller
     {
         /** @var Cart $cart */
         $cart = App::make('Cart');
-        $cart->setSessionId(Session::getId());
+
+        //make sure session is started, grab id:
+        if (!Session::isStarted()) {
+            Session::start();
+        }
+
+        $sessionId = Session::getId();
+        $cart->setSessionId($sessionId);
 
         //set attributes from request:
         $cart->cacheAttributes($request->request);
 
-        $cart->persist();
-
-        return redirect()->route('frontend.package.essentials.male')->withFlashSuccess('Success!');
+        return redirect()->route('frontend.package.essentials.male', ['step' => 2])->withFlashSuccess('Success!');
     }
 
 }

--- a/app/Store/Cart.php
+++ b/app/Store/Cart.php
@@ -55,19 +55,30 @@ class Cart
     public function cacheAttributes(ParameterBag $bag)
     {
         //resolve package & inject:
-        $package = $this->modelResolver->resolvePackage($bag->get('package_id'));
-        $this->setPackage($package);
+        $this->setPackage($bag->get('package_id'));
+
+        //check if request has any product selections:
+        if ($bag->has('sku')) {
+            $this->addProduct($bag->get('sku'));
+        }
 
         //add later:
         //$this->setSubscription($this->resolveSubscription($bag->get('subscription_id')));
     }
 
-    public function resolveAndAddProduct(ParameterBag $bag)
+    public function addProduct($sku)
     {
         //resolve product:
-        $product = $this->modelResolver->resolveStartupProduct($bag->get('sku'));
-        $this->addProduct($product);
+        $product = $this->modelResolver->resolveStartupProduct($sku);
+        array_push($this->products, $product);
+        $this->addRedisProduct($product);
     }
 
+    private function setPackage($package_id)
+    {
+       $package = $this->modelResolver->resolvePackage($package_id);
+       $this->package = $package;
+       $this->setRedisPackage($package);
+    }
 
 }

--- a/app/Store/ModelResolver.php
+++ b/app/Store/ModelResolver.php
@@ -43,9 +43,10 @@ class ModelResolver
         return $this->productRepo->find($product_id);
     }
 
-    public function resolveStartupProduct($idsOrArray)
+    public function resolveStartupProduct($sku)
     {
-        $data = $this->startupProductRepo->getBySku($idsOrArray)->toArray();
+        $data = $this->startupProductRepo->getBySku($sku)->toArray();
+        //transform $data into an actual StartupProduct object:
         return StartupProduct::find($data[0]->id);
     }
 

--- a/app/Store/Traits/Redisable.php
+++ b/app/Store/Traits/Redisable.php
@@ -10,6 +10,7 @@ use App\Models\Products\ProductsCategory;
 use App\Models\Store\StartupProduct;
 use App\Models\Subscription\Packages;
 use App\Models\Subscription\Subscription;
+use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Support\Facades\Redis;
 
 /**
@@ -21,12 +22,12 @@ use Illuminate\Support\Facades\Redis;
  */
 trait Redisable
 {
-    public function addProduct(StartupProduct $product)
+    public function addRedisProduct(StartupProduct $product)
     {
         Redis::rpush('cart:' . $this->sessionId . ':products', $product);
     }
 
-    public function setPackage(Packages $package)
+    public function setRedisPackage(Packages $package)
     {
         Redis::rpush('cart:' . $this->sessionId . ':package', $package);
     }
@@ -46,10 +47,9 @@ trait Redisable
         Redis::save();
     }
 
-    public function __destruct()
+    public function test()
     {
-        Redis::del('cart:' . $this->sessionId . ':products');
-        Redis::del('cart:' . $this->sessionId . ':subscription');
-        Redis::del('cart:' . $this->sessionId . ':package');
+        /** @var PredisConnection $connection */
+        $connection = Redis::connection();
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -271,6 +271,7 @@ return [
          */
         'ModelResolver' => App\Store\ModelResolver::class,
         'Cart'          => App\Store\Cart::class,
+        'StoreRequest'  => App\Http\Requests\Frontend\Store\StoreRequest::class,
 
     ],
 


### PR DESCRIPTION
The cart object now handles tracking the user's order via Redis.

Fixed the issue of the data not being saved to redis -- The reason it was happening was because of a rouge __destruct() method in the Redisable trait (removed). 

Redis now operational 